### PR TITLE
feat : 질문 유형 통계를 위한 category 추가 (#118)

### DIFF
--- a/app/graph/nodes/answer/answer_generate.py
+++ b/app/graph/nodes/answer/answer_generate.py
@@ -45,7 +45,7 @@ def make_answer_generate_node(llm: OpenAILLM):
                 "chunks_used": 0,
                 "answer_length": len(answer),
             }
-            return {"answer_text": answer, "trace": trace}
+            return {"answer_text": answer, "category": "INFORMATION", "trace": trace}
 
         # ── 컨텍스트 조립 ──────────────────────────────────────────────
         def _format_doc(i: int, c: dict) -> str:
@@ -124,6 +124,6 @@ def make_answer_generate_node(llm: OpenAILLM):
             "answer_length": len(answer),
         }
 
-        return {"answer_text": answer, "trace": trace}
+        return {"answer_text": answer, "category": "INFORMATION", "trace": trace}
 
     return answer_generate_node

--- a/app/graph/nodes/answer/event_node.py
+++ b/app/graph/nodes/answer/event_node.py
@@ -106,6 +106,7 @@ def make_event_node(llm: OpenAILLM):
             return {
                 "answer_text": "",
                 "check_result": "bad",
+                "category": "OPERATION",
                 "trace": trace,
             }
 
@@ -187,6 +188,7 @@ def make_event_node(llm: OpenAILLM):
         return {
             "answer_text": answer_text,
             "check_result": check_result,
+            "category": "OPERATION",
             "trace": trace,
         }
 

--- a/app/graph/nodes/answer/smalltalk_node.py
+++ b/app/graph/nodes/answer/smalltalk_node.py
@@ -69,6 +69,6 @@ def make_smalltalk_node(llm: OpenAILLM):
         trace = append_trace_flow(state, "smalltalk")
         trace["smalltalk"] = {"user_language": user_language, "check_result": check_result}
 
-        return {"answer_text": answer, "check_result": check_result, "trace": trace}
+        return {"answer_text": answer, "check_result": check_result, "category": "SMALLTALK", "trace": trace}
 
     return smalltalk_node

--- a/app/graph/nodes/answer/struct_db_node.py
+++ b/app/graph/nodes/answer/struct_db_node.py
@@ -106,7 +106,6 @@ def make_struct_db_node(llm: OpenAILLM):
         raw = ""
 
         _allowed_emotions = {"GUIDING", "HAPPY", "THINKING", "SORRY", "EXCITED"}
-        _allowed_categories = {"DIRECTION", "HOURS", "FACILITY", "HISTORY", "GENERAL", "ERROR"}
 
         try:
             raw = llm.chat(messages, max_tokens=200)
@@ -125,8 +124,6 @@ def make_struct_db_node(llm: OpenAILLM):
                 place_id = None
             raw_emotion = parsed.get("emotion", "GUIDING")
             emotion = raw_emotion if raw_emotion in _allowed_emotions else "GUIDING"
-            raw_category = parsed.get("category", "DIRECTION")
-            category = raw_category if raw_category in _allowed_categories else "DIRECTION"
         except (json.JSONDecodeError, ValueError, TypeError) as e:
             # JSON 파싱 실패 → raw 자체를 답변으로 사용
             answer_text = raw
@@ -153,7 +150,7 @@ def make_struct_db_node(llm: OpenAILLM):
             "answer_text": answer_text,
             "place_id": place_id,
             "emotion": emotion,
-            "category": category,
+            "category": "DIRECTION",
             "check_result": "good",
             "trace": trace,
         }


### PR DESCRIPTION
#118 

질문에 대한 유형 통계를 위해 각 노드 답변에 카테고리를 추가하였습니다.
해당 카테고리는 spring core에서 tb_chat_message에 저장됩니다.
